### PR TITLE
Add instruction to advance phase indicator

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -68,6 +68,7 @@
   "turnBot": {
     "title": "V.I.C.I",
     "reset": "V.I.C.I führt einen <b>Reset</b> durch.",
+    "resetAdvance": "Bewege den <i>Phasenanzeiger</i> zum nächsten <i>Resetfeld</i>.",
     "removeAttributeChip": "Entferne <b>Attributsplatine</b> {chip}.",
     "removeIncomeChip": "Entferne <b>Einkommensplatine</b> {chip}."
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -68,6 +68,7 @@
   "turnBot": {
     "title": "V.I.C.I",
     "reset": "V.I.C.I does a <b>Reset</b>.",
+    "resetAdvance": "Advance the <i>phase indicator</i> to the next <i>reset space</i>.",
     "removeAttributeChip": "Remove <b>attribute chip</b> {chip}.",
     "removeIncomeChip": "Remove <b>income chip</b> {chip}."
   },

--- a/src/views/TurnBot.vue
+++ b/src/views/TurnBot.vue
@@ -11,6 +11,7 @@
       <AppIcon name="phase-indicator" class="phase-indicator"/>
       <span v-html="t('turnBot.reset')"></span>
     </p>
+    <p v-html="t('turnBot.resetAdvance')"></p>
   </template>
   <template v-else>
     <BotActionsDisplay :navigationState="navigationState" :botActions="botActions"/>


### PR DESCRIPTION
New i18n keys introduced:
```
turnBot.resetAdvance
```

Fixes #9 
