### PR TITLE
Do not reset count of red/blue dots at end of the round

### DIFF
--- a/src/util/NavigationState.ts
+++ b/src/util/NavigationState.ts
@@ -147,9 +147,6 @@ function getPreviousBotPersistence(state: State, round: number, turn: number) : 
   if (round > 1) {
     const lastRoundBotPersistence = getPreviousBotPersistence(state, round - 1, MAX_TURN)
     if (lastRoundBotPersistence) {
-      // reset dot counters for new round
-      lastRoundBotPersistence.blueDotCount = 0
-      lastRoundBotPersistence.redDotCount = 0
       return lastRoundBotPersistence
     }
   }

--- a/src/util/NavigationState.ts
+++ b/src/util/NavigationState.ts
@@ -73,7 +73,7 @@ export default class NavigationState {
         redDotCount = 0
       }
       // draw next card, count dots
-      if (this.player == Player.BOT) {
+      if (this.player == Player.BOT && route.name == 'TurnBot') {
         const nextCard = this.cardDeck.draw()
         this.blueDotCount = blueDotCount + nextCard.blueDotCount
         this.redDotCount = redDotCount + nextCard.redDotCount

--- a/tests/unit/services/BotActions.spec.ts
+++ b/tests/unit/services/BotActions.spec.ts
@@ -99,10 +99,7 @@ describe('services/BotActions', () => {
     const navigationState = new NavigationState(route, getState(DifficultyLevel.BEGINNER))
 
     const botActions = new BotActions(Cards.get(13), navigationState)
-    expect(botActions.isReset).to.eq(false)
-    expect(botActions.items).to.eql([
-      { action: Action.GAIN_VP, count: 4 }
-    ])
+    expect(botActions.isReset).to.eq(true)
   })
 
   it('scoringActions-last-era-scoring-category', () => {

--- a/tests/unit/util/NavigationState.spec.ts
+++ b/tests/unit/util/NavigationState.spec.ts
@@ -103,8 +103,8 @@ describe('util/NavigationState', () => {
     expect(navigationState.cardDeck.toPersistence()).to.eql({pile:[4],discard:[3,2,1]})
     expect(navigationState.evolutionCount).to.eq(2)
     expect(navigationState.prosperityCount).to.eq(1)
-    expect(navigationState.blueDotCount).to.eq(2)  // card3.blueDotCount = 2
-    expect(navigationState.redDotCount).to.eq(1)   // card3.redDotCount = 1
+    expect(navigationState.blueDotCount).to.eq(5)  // taken over from last round
+    expect(navigationState.redDotCount).to.eq(2)   // taken over from last round
     expect(navigationState.actionRoll).to.greaterThanOrEqual(1)
   })
 


### PR DESCRIPTION
Same as the player VICI takes over it current "dice state" (it's card deck) to the next round. the counting of red/blue dots continues as normal in VICIs turn in the new round.
Currently, against the rules, this count was reset on the start of a new round.